### PR TITLE
module: Show error name in promise rejection on auth error

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNSdkSpotifyModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSdkSpotifyModule.java
@@ -331,7 +331,7 @@ public class RNSdkSpotifyModule extends ReactContextBaseJavaModule
                     resolve(response);
                     break;
                 case ERROR:
-                    reject(E_AUTH_ERROR, "Error during authorisation");
+                    reject(E_AUTH_ERROR, "Error during authorisation: " + response.getError());
                     break;
                 default: // cancelled
                     reject(E_CANCELLED, "User cancelled the operation");


### PR DESCRIPTION
The default error message "Error occurred during authorisation" is
not google-able, nor is it useful